### PR TITLE
[finishes #5243847] Added yearly pages to organize dramas by year

### DIFF
--- a/app/controllers/dramas_controller.rb
+++ b/app/controllers/dramas_controller.rb
@@ -3,7 +3,27 @@ class DramasController < ApplicationController
 
   # GET /dramas or /dramas.json
   def index
-    @dramas = Drama.all.order(created_at: :desc)
+    @year = Time.now.year
+    @dramas = Drama.where("strftime('%Y', created_at) = ?", @year.to_s).order(created_at: :desc)
+    @dramas_count = Drama.all.count
+    # @dramas = Drama.all.order(created_at: :desc)
+  end
+
+  # GET /dramas/year/202X
+  def by_year
+    year = params[:year].to_i
+    current_year = Time.now.year
+    if year < 2022
+      flash[:warning] = "I started watching KDramas in 2022. 💕"
+      redirect_to dramas_path
+    elsif year > current_year
+      flash[:warning] = "Hey, you! Stop it! 💞 You can't see the future! "
+      redirect_to dramas_path
+    else
+      @dramas = Drama.where("strftime('%Y', created_at) = ?", year.to_s).order(created_at: :desc)
+      @dramas_count = @dramas.count
+      render 'year'
+    end
   end
 
   # GET /dramas/1 or /dramas/1.json

--- a/app/views/dramas/index.html.erb
+++ b/app/views/dramas/index.html.erb
@@ -4,37 +4,16 @@
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 <% end %>
+
 <div class="container">
   <div class="d-flex justify-content-between align-items-center my-4">
     <h1 class="text-muted">Dramas</h1>
+
 
     <%= link_to search_tmdb_path, class: "btn btn-outline-secondary", role: "button" do %>
     <i class="bi bi-search-heart-fill"></i>
       Search Drama
     <% end %>
   </div>
-
-  <div class="row my-4">
-    <% @dramas.each do |drama| %>
-      <div class="col-lg-4 col-md-6 col-sm-12">
-        <%= link_to drama, class: "movie-card-link card-container d-flex align-items-center justify-content-center" do %>
-          <article style="width: 100%; height: auto;" class="movie-card my-4">
-            <% image_url = drama.backdrop.present? ? "https://image.tmdb.org/t/p/w500#{drama.backdrop}" : "https://source.unsplash.com/random/355x200/?korea" %>
-            <div class="card-image">
-              <img src="<%= image_url %>" style="height: auto; width: 100%;" alt="Poster Image for <%= drama.title %>">
-            </div>
-            <div class="content">
-              <h1 class="movie-card-title"><%= drama.title %></h1>
-              <div class="infos mt-2">
-                <%= render partial: 'rating', locals: { drama: drama } %>
-                <span>·&nbsp;&nbsp;<%= Time.parse(drama.air_date).strftime("%Y") %></span>
-              </div>
-              <p class="synopsis"><%= truncate(drama.overview, length: 200) %></p>
-            </div>
-          </article>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-
+  <%= render partial: 'shared/dramas_list', locals: { dramas: @dramas, dramas_count: @dramas_count, year: @year } %>
 </div>

--- a/app/views/dramas/year.html.erb
+++ b/app/views/dramas/year.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <h1 class="text-muted">Dramas · <%= params[:year] || Time.now.year %></h1>
+  <%= render partial: 'shared/dramas_list', locals: { dramas: @dramas, dramas_count: @dramas_count, year: params[:year] } %>
+</div>

--- a/app/views/shared/_dramas_list.html.erb
+++ b/app/views/shared/_dramas_list.html.erb
@@ -1,0 +1,43 @@
+<div class="row my-4">
+  <% @dramas.each do |drama| %>
+    <div class="col-lg-4 col-md-6 col-sm-12">
+      <%= link_to drama, class: "movie-card-link card-container d-flex align-items-center justify-content-center" do %>
+        <article style="width: 100%; height: auto;" class="movie-card my-4">
+          <% image_url = drama.backdrop.present? ? "https://image.tmdb.org/t/p/w500#{drama.backdrop}" : "https://source.unsplash.com/random/355x200/?korea" %>
+          <div class="card-image">
+            <img src="<%= image_url %>" style="height: auto; width: 100%;" alt="Poster Image for <%= drama.title %>">
+          </div>
+          <div class="content">
+            <h1 class="movie-card-title"><%= drama.title %></h1>
+            <div class="infos mt-2">
+              <%= render partial: 'rating', locals: { drama: drama } %>
+              <span>·&nbsp;&nbsp;<%= Time.parse(drama.air_date).strftime("%Y") %></span>
+            </div>
+            <p class="synopsis"><%= truncate(drama.overview, length: 200) %></p>
+          </div>
+        </article>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<ul class="nav nav-pills my-4 d-flex justify-content-between">
+  <div class="d-flex align-items-center">
+    <button type="button" class="btn bg-light text-dark btn-lg disabled">
+      <i class="bi bi-eye"></i>&nbsp;&nbsp;&nbsp;<span class="badge bg-secondary"><%= dramas_count %></span>
+    </button> 
+  </div>
+  <div class="d-flex">
+    <li class="nav-item">
+      <%= link_to dramas_path, class: "nav-link #{'bg-secondary text-white' if year.to_i == Time.now.year} #{'text-secondary' unless year.to_i == Time.now.year}" do %>
+        <i class="bi bi-house"></i>
+      <% end %>
+    </li>
+    <% [2024, 2023, 2022].each do |y| %>
+      <% next if y == Time.now.year %>
+      <li class="nav-item">
+        <%= link_to y, dramas_by_year_path(year: y), class: "nav-link #{'bg-secondary text-white' if year.to_i == y} #{'text-secondary' unless year.to_i == y}" %>
+      </li>
+    <% end %>
+  </div>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   get 'about', to: 'pages#about'
   root "pages#home"
   get 'search', to: 'dramas#search_tmdb', as: 'search_tmdb'
+
+  get 'dramas/year/:year', to: 'dramas#by_year', as: 'dramas_by_year'
 end


### PR DESCRIPTION
Add pages titled by year so that I can have the current year's dramas. The previous years will be available at the bottom of the current year page and dramas I watched for that corresponding year will be in that year's page.